### PR TITLE
Change github pages link to have correct TLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ available on GitHub, and released under the MIT license.
 
 ## Prebuilt indexes
 
-* AUR: [online](http://ternstor.github.com/distrofonts/aur.html),
-[gzip](http://ternstor.github.com/distrofonts/aur.tar.gz).
+* AUR: [online](http://ternstor.github.io/distrofonts/aur.html),
+[gzip](http://ternstor.github.io/distrofonts/aur.tar.gz).
 * ABS: 
-    * Community: [online](http://ternstor.github.com/distrofonts/community.html),
-    [gzip](http://ternstor.github.com/distrofonts/community.tar.gz).
-    * Extra: [online](http://ternstor.github.com/distrofonts/extra.html),
-    [gzip](http://ternstor.github.com/distrofonts/extra.tar.gz).
+    * Community: [online](http://ternstor.github.io/distrofonts/community.html),
+    [gzip](http://ternstor.github.io/distrofonts/community.tar.gz).
+    * Extra: [online](http://ternstor.github.io/distrofonts/extra.html),
+    [gzip](http://ternstor.github.io/distrofonts/extra.tar.gz).
 
 ## Dependencies
 

--- a/archfonts.py
+++ b/archfonts.py
@@ -7,13 +7,13 @@ trees.
 
 Prebuilt indexes:
 
-* AUR: [online](http://ternstor.github.com/archfonts/aur.html),
-[gzip](http://ternstor.github.com/archfonts/aur.tar.gz).
+* AUR: [online](http://ternstor.github.io/archfonts/aur.html),
+[gzip](http://ternstor.github.io/archfonts/aur.tar.gz).
 * ABS:
-    * Community: [online](http://ternstor.github.com/archfonts/community.html),
-    [gzip](http://ternstor.github.com/archfonts/community.tar.gz).
-    * Extra: [online](http://ternstor.github.com/archfonts/extra.html)
-    [gzip](http://ternstor.github.com/archfonts/extra.tar.gz).
+    * Community: [online](http://ternstor.github.io/archfonts/community.html),
+    [gzip](http://ternstor.github.io/archfonts/community.tar.gz).
+    * Extra: [online](http://ternstor.github.io/archfonts/extra.html)
+    [gzip](http://ternstor.github.io/archfonts/extra.tar.gz).
 
 Dependencies: ttf2png, pacman (makepkg), imagemagick.
 

--- a/docs/archfonts.html
+++ b/docs/archfonts.html
@@ -23,13 +23,13 @@ found in <a href="http://www.archlinux.org/">Archlinux</a> AUR or ABS source
 trees.</p>
 <p>Prebuilt indexes:</p>
 <ul>
-<li>AUR: <a href="http://ternstor.github.com/archfonts/aur.html">online</a>,
-<a href="http://ternstor.github.com/archfonts/aur.tar.gz">gzip</a>.</li>
+<li>AUR: <a href="http://ternstor.github.io/archfonts/aur.html">online</a>,
+<a href="http://ternstor.github.io/archfonts/aur.tar.gz">gzip</a>.</li>
 <li>ABS:<ul>
-<li>Community: <a href="http://ternstor.github.com/archfonts/community.html">online</a>,
-<a href="http://ternstor.github.com/archfonts/community.tar.gz">gzip</a>.</li>
-<li>Extra: <a href="http://ternstor.github.com/archfonts/extra.html">online</a>
-<a href="http://ternstor.github.com/archfonts/extra.tar.gz">gzip</a>.</li>
+<li>Community: <a href="http://ternstor.github.io/archfonts/community.html">online</a>,
+<a href="http://ternstor.github.io/archfonts/community.tar.gz">gzip</a>.</li>
+<li>Extra: <a href="http://ternstor.github.io/archfonts/extra.html">online</a>
+<a href="http://ternstor.github.io/archfonts/extra.tar.gz">gzip</a>.</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
ternstor.github.com should be replaced with ternstor.github.io to point the GH pages link properly. Fixes #3 